### PR TITLE
Update documentation-guidelines.html.md

### DIFF
--- a/bevry/01-community/documentation-guidelines.html.md
+++ b/bevry/01-community/documentation-guidelines.html.md
@@ -4,7 +4,7 @@ All pull requests must conform to the following criteria in order to get merged 
 	We use [GitHub Flavoured Markdown](http://github.github.com/github-flavored-markdown/) for all our documents. This can be seen by the usage of the `.md` extension on our files.
 
 - ### Single paragraph pull requests only
-	Each pull request should only alter one paragrah each, pull requests that alter more than one paragraph at a time will likely need to be redone. This is because monolithic/bundled pull requests are impossible to merge in due to the extreme level of overhead they cause by conflicting +1s and -1s in the same pull request, getting out of date with other changes quicker, getting in conflict with other merged in changes quicker.
+	Each pull request should only alter one paragraph.  Pull requests that alter more than one paragraph at a time will likely need to be redone. This is because monolithic/bundled pull requests are impossible to merge in due to the extreme level of overhead they cause by conflicting +1s and -1s in the same pull request, getting out of date with other changes quicker, getting in conflict with other merged in changes quicker.
 
 - ### International/British English for Text, USA/American English for Code
 	We love it when people fix spelling errors and typos! We use International/British English for text (only 27% of our visitors are from the USA), and USA/American English for code (this is more a technical constraint). Code examples should (where it makes sense to) comply with the [Bevry Coding Standards](http://bevry.me/bevry/coding-standards).


### PR DESCRIPTION
Fixed the word paragrah in the section `Single paragraph pull requests only`, and removed the word each.  Split up that sentence.
