### PR TITLE
Update documentation-guidelines.html.md

### DIFF
--- a/bevry/01-community/documentation-guidelines.html.md
+++ b/bevry/01-community/documentation-guidelines.html.md
@@ -1,4 +1,4 @@
-Pull requests must conform to the following criteria:
+Help in improving the documentation is very much welcome.  We love it when people fix spelling errors and typos!  Pull requests must conform to the following criteria:
 
 - ### GitHub Flavoured Markdown
 	We use [GitHub Flavoured Markdown](http://github.github.com/github-flavored-markdown/) for all our documents.
@@ -6,8 +6,8 @@ Pull requests must conform to the following criteria:
 - ### Single paragraph pull requests only
 	Each pull request should only alter one paragraph.  This makes the process of merging the change simple.
 
-- ### International/British English for Text, USA/American English for Code
-	We love it when people fix spelling errors and typos! We use International/British English for text (only 27% of our visitors are from the USA), and USA/American English for code. Code examples should (where it makes sense to) comply with the [Bevry Coding Standards](http://bevry.me/bevry/coding-standards).
+- ### Code Examples
+	Code examples should (where it makes sense to) comply with the [Bevry Coding Standards](http://bevry.me/bevry/coding-standards).
 
 - ### Explain changes
 	Fixing grammar as well any other sentence restructuring will require a description along with the pull request on why this change is better than the original. It turns out that such changes are largely subjective, and that the original may be that way for sound reasons.
@@ -16,6 +16,6 @@ Pull requests must conform to the following criteria:
 	We are not yet ready to add resources to community documentation and videos yet. We need to figure out the best way to present the data while avoiding common pitfalls like out of sync or conflicting documentation.
 
 - ### Use the "Files Changed" tab to comment on pull requests
-	When commenting on pull request changes, instead of commenting on individual commits, use the pull request's "Files Changed" tab. This allows your comments to persist as the pull request developers, rather than be forgotten when the next commit comes in.
+	When commenting on pull request changes, instead of commenting on individual commits, use the pull request's "Files Changed" tab. This allows your comments to persist, rather than be forgotten when the next commit comes in.
 
 [Discussion about this criteria here.](https://github.com/docpad/documentation/issues/63)


### PR DESCRIPTION
This requirement seems ... a bit silly:

```
International/British English for Text, USA/American English for Code

We love it when people fix spelling errors and typos! We use International/British English for text (only 27% of our visitors are from the USA), and USA/American English for code. Code examples should (where it makes sense to) comply with the Bevry Coding Standards.
```

I changed it a bit.
